### PR TITLE
secrets: detect raw DER-encoded private keys (PKCS#8/PKCS#1/SEC1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(mithril
   src/engine.cpp
   src/userrules.cpp
   src/credstore.cpp
+  src/derkey.cpp
   src/binver.cpp
   src/filever.cpp
   src/inflate.cpp
@@ -63,6 +64,7 @@ add_executable(mithril_unit
   src/engine.cpp
   src/userrules.cpp
   src/credstore.cpp
+  src/derkey.cpp
   src/binver.cpp
   src/filever.cpp
   src/inflate.cpp

--- a/src/derkey.cpp
+++ b/src/derkey.cpp
@@ -1,0 +1,285 @@
+// derkey.cpp — raw DER private-key scanner. See derkey.hpp.
+//
+// ASN.1/DER shapes recognized (all reachable with no PEM wrapper):
+//   PKCS#8  PrivateKeyInfo   SEQ { INTEGER 0, AlgId SEQ { OID [, params] }, OCTET STRING }
+//   PKCS#1  RSAPrivateKey    SEQ { INTEGER 0, INTEGER n, INTEGER e, ... }   (9 INTEGERs)
+//   SEC1    ECPrivateKey     SEQ { INTEGER 1, OCTET STRING d, [0] params, [1] pubkey }
+//
+// Strategy: Aho-Corasick over a few length-independent byte anchors that begin
+// the SEQUENCE *content* (the version INTEGER), then for each hit recover the
+// enclosing SEQUENCE header and run a full TLV parse. Every byte read goes
+// through the bounds-checked Reader, so a hostile length just fails the parse.
+#include "derkey.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <string>
+
+#include "ahocorasick.hpp"
+
+namespace ft {
+
+namespace {
+
+// ---- ASN.1 DER TLV --------------------------------------------------------
+
+struct Tlv {
+    uint8_t tag = 0;
+    size_t body = 0;  // offset of the content
+    size_t len = 0;   // content length
+    size_t end = 0;   // body + len (offset just past this TLV)
+};
+
+std::optional<uint8_t> u8(const Reader& r, size_t off) { return r.at<uint8_t>(off, Endian::Big); }
+
+// Parse a definite-length DER TLV at `off`. Rejects indefinite form and >4 length
+// bytes (neither occurs in a DER private key). nullopt on any overrun.
+std::optional<Tlv> tlv(const Reader& r, size_t off) {
+    auto tag = u8(r, off);
+    auto l0 = u8(r, off + 1);
+    if (!tag || !l0) return std::nullopt;
+    size_t hdr, len;
+    if (*l0 < 0x80) {
+        len = *l0;
+        hdr = 2;
+    } else {
+        int nb = *l0 & 0x7f;
+        if (nb == 0 || nb > 4) return std::nullopt;  // indefinite / absurd length
+        len = 0;
+        for (int i = 0; i < nb; ++i) {
+            auto b = u8(r, off + 2 + static_cast<size_t>(i));
+            if (!b) return std::nullopt;
+            len = (len << 8) | *b;
+        }
+        hdr = 2 + static_cast<size_t>(nb);
+    }
+    const size_t body = off + hdr;
+    const size_t end = body + len;
+    if (end < body || end > r.size()) return std::nullopt;  // overflow / past EOF
+    return Tlv{*tag, body, len, end};
+}
+
+bool oid_is(const Reader& r, const Tlv& t, std::span<const uint8_t> want) {
+    if (t.tag != 0x06 || t.len != want.size()) return false;
+    auto b = r.bytes(t.body, t.len);
+    return b && std::equal(want.begin(), want.end(), b->begin());
+}
+
+// Known algorithm/curve OIDs (the bytes after `06 <len>`).
+constexpr uint8_t OID_RSA[] = {0x2A, 0x86, 0x48, 0x86, 0xF7, 0x0D, 0x01, 0x01, 0x01};
+constexpr uint8_t OID_EC[] = {0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x02, 0x01};
+constexpr uint8_t OID_ED25519[] = {0x2B, 0x65, 0x70};
+constexpr uint8_t OID_ED448[] = {0x2B, 0x65, 0x71};
+constexpr uint8_t OID_X25519[] = {0x2B, 0x65, 0x6E};
+constexpr uint8_t OID_X448[] = {0x2B, 0x65, 0x6F};
+constexpr uint8_t OID_P256[] = {0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07};
+constexpr uint8_t OID_P384[] = {0x2B, 0x81, 0x04, 0x00, 0x22};
+constexpr uint8_t OID_P521[] = {0x2B, 0x81, 0x04, 0x00, 0x23};
+constexpr uint8_t OID_SECP256K1[] = {0x2B, 0x81, 0x04, 0x00, 0x0A};
+
+std::string curve_from_oid(const Reader& r, const Tlv& oid) {
+    if (oid_is(r, oid, OID_P256)) return "secp256r1";
+    if (oid_is(r, oid, OID_P384)) return "secp384r1";
+    if (oid_is(r, oid, OID_P521)) return "secp521r1";
+    if (oid_is(r, oid, OID_SECP256K1)) return "secp256k1";
+    return "";
+}
+
+std::string curve_from_scalar(size_t n) {
+    switch (n) {
+        case 32: return "P-256";
+        case 48: return "secp384r1";
+        case 66: return "secp521r1";
+        default: return "";
+    }
+}
+
+// Bit size of an INTEGER's value (drop a single DER sign-padding 0x00).
+size_t int_bits(const Reader& r, const Tlv& i) {
+    size_t len = i.len;
+    auto first = u8(r, i.body);
+    if (len > 1 && first && *first == 0x00) --len;
+    return len * 8;
+}
+
+// ---- key classification ---------------------------------------------------
+
+struct Key {
+    size_t start = 0;  // offset of the outer SEQUENCE tag
+    size_t end = 0;    // offset just past the key
+    std::string label;
+};
+
+// PKCS#8: label from the AlgorithmIdentifier (+ modulus/curve peek). `after_alg`
+// is the offset of the privateKey OCTET STRING that follows the AlgId.
+std::string pkcs8_label(const Reader& r, const Tlv& algid, size_t after_alg) {
+    auto oid = tlv(r, algid.body);
+    if (!oid || oid->tag != 0x06) return "";
+
+    if (oid_is(r, *oid, OID_RSA)) {
+        // privateKey OCTET STRING -> RSAPrivateKey SEQ -> version, modulus.
+        auto oct = tlv(r, after_alg);
+        if (oct && oct->tag == 0x04) {
+            auto inner = tlv(r, oct->body);
+            if (inner && inner->tag == 0x30) {
+                auto ver = tlv(r, inner->body);
+                if (ver && ver->tag == 0x02) {
+                    auto mod = tlv(r, ver->end);
+                    if (mod && mod->tag == 0x02)
+                        return "RSA-" + std::to_string(int_bits(r, *mod));
+                }
+            }
+        }
+        return "RSA";
+    }
+    if (oid_is(r, *oid, OID_EC)) {
+        auto params = tlv(r, oid->end);  // named curve OID
+        std::string c = (params && params->tag == 0x06) ? curve_from_oid(r, *params) : "";
+        return c.empty() ? "EC" : ("EC " + c);
+    }
+    if (oid_is(r, *oid, OID_ED25519)) return "Ed25519";
+    if (oid_is(r, *oid, OID_ED448)) return "Ed448";
+    if (oid_is(r, *oid, OID_X25519)) return "X25519";
+    if (oid_is(r, *oid, OID_X448)) return "X448";
+    return "";  // unknown algorithm -> not a key we vouch for
+}
+
+// Given an outer SEQUENCE whose content is [cstart, cend), decide whether it is a
+// private key and, if so, its label. Requires the children to consume the
+// SEQUENCE exactly — the structural check that rejects coincidental byte runs.
+std::optional<std::string> classify(const Reader& r, size_t cstart, size_t cend) {
+    auto ver = tlv(r, cstart);
+    if (!ver || ver->tag != 0x02 || ver->len != 1) return std::nullopt;
+    auto vb = u8(r, ver->body);
+    if (!vb) return std::nullopt;
+    const uint8_t version = *vb;
+
+    if (version == 0) {
+        auto nxt = tlv(r, ver->end);
+        if (!nxt) return std::nullopt;
+
+        if (nxt->tag == 0x30) {  // PKCS#8: AlgorithmIdentifier SEQUENCE
+            std::string label = pkcs8_label(r, *nxt, nxt->end);
+            if (label.empty()) return std::nullopt;
+            auto oct = tlv(r, nxt->end);  // privateKey OCTET STRING
+            if (!oct || oct->tag != 0x04) return std::nullopt;
+            if (oct->end > cend) return std::nullopt;  // must fit the SEQUENCE
+            return label;
+        }
+        if (nxt->tag == 0x02) {  // PKCS#1 RSAPrivateKey: version + 8 INTEGERs
+            size_t bits = int_bits(r, *nxt);
+            size_t count = 2;  // version + modulus
+            size_t p = nxt->end;
+            while (p < cend) {
+                auto c = tlv(r, p);
+                if (!c || c->tag != 0x02) return std::nullopt;  // all fields are INTEGERs
+                ++count;
+                p = c->end;
+            }
+            if (p != cend || count != 9) return std::nullopt;
+            if (bits < 512) return std::nullopt;  // implausible modulus
+            return "RSA-" + std::to_string(bits);
+        }
+        return std::nullopt;
+    }
+
+    if (version == 1) {  // SEC1 ECPrivateKey
+        auto oct = tlv(r, ver->end);
+        if (!oct || oct->tag != 0x04) return std::nullopt;
+        std::string curve = curve_from_scalar(oct->len);
+        size_t p = oct->end;
+        while (p < cend) {  // optional [0] params, [1] publicKey
+            auto c = tlv(r, p);
+            if (!c) return std::nullopt;
+            if (c->tag == 0xA0) {  // parameters -> named curve OID
+                auto oid = tlv(r, c->body);
+                if (oid && oid->tag == 0x06) {
+                    std::string cc = curve_from_oid(r, *oid);
+                    if (!cc.empty()) curve = cc;
+                }
+            }
+            p = c->end;
+        }
+        if (p != cend || curve.empty()) return std::nullopt;
+        return "EC " + curve;
+    }
+    return std::nullopt;
+}
+
+// An anchor lands on the version INTEGER (first child of the outer SEQUENCE).
+// Recover the enclosing SEQUENCE header, then classify.
+std::optional<Key> parse_at_version(const Reader& r, size_t vpos) {
+    for (size_t hdr = 2; hdr <= 6 && hdr <= vpos; ++hdr) {
+        auto seq = tlv(r, vpos - hdr);
+        if (!seq || seq->tag != 0x30 || seq->body != vpos) continue;
+        if (auto label = classify(r, seq->body, seq->end))
+            return Key{vpos - hdr, seq->end, *label};
+    }
+    return std::nullopt;
+}
+
+// Length-independent anchors that begin a private-key SEQUENCE's content.
+const AhoCorasick& anchors() {
+    static const AhoCorasick ac = [] {
+        AhoCorasick a;
+        const std::vector<std::vector<uint8_t>> pats = {
+            {0x02, 0x01, 0x00, 0x30},        // PKCS#8 (version 0, AlgId SEQUENCE)
+            {0x02, 0x01, 0x00, 0x02, 0x82},  // PKCS#1 RSA, modulus 256..65535 B (>=2048-bit)
+            {0x02, 0x01, 0x00, 0x02, 0x81},  // PKCS#1 RSA, modulus 128..255 B  (~1024-bit)
+            {0x02, 0x01, 0x01, 0x04, 0x20},  // SEC1 EC, 32-byte scalar (P-256/secp256k1)
+            {0x02, 0x01, 0x01, 0x04, 0x30},  // SEC1 EC, 48-byte scalar (P-384)
+            {0x02, 0x01, 0x01, 0x04, 0x42},  // SEC1 EC, 66-byte scalar (P-521)
+        };
+        for (uint32_t i = 0; i < pats.size(); ++i) a.add(pats[i], i);
+        a.build();
+        return a;
+    }();
+    return ac;
+}
+
+}  // namespace
+
+std::vector<Finding> scan_der_private_keys(const Reader& r) {
+    if (r.size() < 8) return {};
+
+    std::vector<Key> hits;
+    anchors().find(r.data(), 0, [&](size_t pos, uint32_t) -> bool {
+        if (auto k = parse_at_version(r, pos)) hits.push_back(*k);
+        return true;
+    });
+    if (hits.empty()) return {};
+
+    // Dedup by overlap: keep the outermost key in any region so a PKCS#8 wrapper
+    // and the PKCS#1 key nested in its OCTET STRING count once. Distinct keys at
+    // distinct offsets (incl. redundant copies of one key) are all kept.
+    std::sort(hits.begin(), hits.end(), [](const Key& a, const Key& b) {
+        return a.start != b.start ? a.start < b.start : a.end > b.end;
+    });
+
+    std::vector<Finding> out;
+    size_t claimed_end = 0;
+    bool have_claim = false;
+    for (const Key& k : hits) {
+        if (have_claim && k.start < claimed_end) continue;  // overlaps a kept key
+        claimed_end = k.end;
+        have_claim = true;
+
+        Finding f;
+        f.offset = k.start;
+        f.size = k.end - k.start;
+        f.type = "der-private-key";
+        f.category = "secret";
+        f.label = k.label + " private key";
+        f.description =
+            "Embedded " + k.label +
+            " private key in raw DER form (no PEM wrapper); text/pattern secret scans miss these";
+        f.set_confidence(Confidence::Structural, "DER private key structurally parsed");
+        out.push_back(std::move(f));
+    }
+    return out;
+}
+
+}  // namespace ft

--- a/src/derkey.hpp
+++ b/src/derkey.hpp
@@ -1,0 +1,32 @@
+// derkey.hpp — structural scan for raw DER-encoded private keys.
+//
+// The content engine (engine.cpp) is text-anchored: it hunts PEM armor
+// ("-----BEGIN ... PRIVATE KEY-----"), `AKIA...`, `api_key=` and the like, over
+// text-ish regions only. A private key embedded in binary firmware as raw DER —
+// PKCS#8 PrivateKeyInfo, PKCS#1 RSAPrivateKey, or SEC1 ECPrivateKey, with no PEM
+// wrapper and no surrounding keyword — has nothing for those anchors to hit and
+// lives in a region the text-ish gate skips. Such keys are invisible to the
+// secrets pass yet are exactly the high-impact finding (a fleet-shared signing
+// or TLS key baked into an image).
+//
+// This module closes that gap: it scans the whole buffer for the DER byte
+// patterns that begin a private key, then *structurally parses* each candidate
+// (a real ASN.1 tag/length walk, no crypto library) to confirm it is a complete,
+// well-formed private key and to name its algorithm and size. Structural parsing
+// — not pattern matching — is what rejects the false positives (class names, CA
+// certificate stores, dictionary words) that defeat text sweeps.
+#pragma once
+
+#include <vector>
+
+#include "finding.hpp"
+#include "reader.hpp"
+
+namespace ft {
+
+// Scan `r` for raw DER private keys. Returns one Finding per distinct key
+// (type "der-private-key", category "secret"), deduplicated so a PKCS#8 wrapper
+// and the PKCS#1 key nested inside it count once. Fully offline and bounds-safe.
+std::vector<Finding> scan_der_private_keys(const Reader& r);
+
+}  // namespace ft

--- a/src/walk.cpp
+++ b/src/walk.cpp
@@ -11,6 +11,7 @@
 
 #include "binver.hpp"
 #include "credstore.hpp"
+#include "derkey.hpp"
 #include "engine.hpp"
 #include "file_map.hpp"
 #include "filever.hpp"
@@ -95,6 +96,11 @@ FileHits scan_one(const fs::path& path, const fs::path& root, const Passes& pass
         auto creds = scan_credstores(fh.path, fm.span());
         fh.secrets.insert(fh.secrets.end(), std::make_move_iterator(creds.begin()),
                           std::make_move_iterator(creds.end()));
+        // Raw DER private keys embedded in binary firmware (no PEM wrapper), which
+        // the text-anchored content engine cannot see. Scans the whole buffer.
+        auto derkeys = scan_der_private_keys(reader);
+        fh.secrets.insert(fh.secrets.end(), std::make_move_iterator(derkeys.begin()),
+                          std::make_move_iterator(derkeys.end()));
     }
     if (passes.sbom) {
         fh.components = scan_sbom(fh.path, fm.span());  // M4 package DBs

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -16,6 +16,9 @@ echo "== unit tests =="
 echo "== integration: secrets =="
 python3 tests/test_secrets.py "./$BUILD/mithril"
 
+echo "== integration: der private keys =="
+python3 tests/test_der_keys.py "./$BUILD/mithril"
+
 echo "== integration: sbom =="
 python3 tests/test_sbom.py "./$BUILD/mithril"
 

--- a/tests/test_der_keys.py
+++ b/tests/test_der_keys.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""test_der_keys.py — integration test for the raw DER private-key scanner.
+
+Generates real private keys with openssl in every DER encoding the scanner
+targets (PKCS#8, PKCS#1, SEC1) across RSA / EC / Ed25519, embeds each in a
+binary blob with non-text padding and NO PEM wrapper, runs the mithril binary
+with `-j --secrets`, and asserts every key is reported as a `der-private-key`
+at its exact offset with the right algorithm label — and that key-shaped bait
+(class names, a lone anchor) produces no finding. Self-skips if openssl is
+absent. No network, no committed fixtures.
+
+Usage: tests/test_der_keys.py [path/to/mithril]   (default: build/mithril)
+"""
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+
+
+def gen_keys(d):
+    """Generate DER keys with openssl. Returns [(filename, expected_label)]."""
+    def sh(cmd):
+        subprocess.run(cmd, cwd=d, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+    # PKCS#8 (genpkey default), plus traditional PKCS#1 / SEC1 via -traditional.
+    sh(["openssl", "genpkey", "-algorithm", "RSA", "-pkeyopt", "rsa_keygen_bits:2048",
+        "-outform", "DER", "-out", "rsa_pkcs8.der"])
+    sh(["bash", "-c", "openssl genrsa 2048 2>/dev/null | "
+        "openssl rsa -traditional -outform DER -out rsa_pkcs1.der 2>/dev/null"])
+    sh(["openssl", "genpkey", "-algorithm", "EC", "-pkeyopt", "ec_paramgen_curve:P-256",
+        "-outform", "DER", "-out", "ec256_pkcs8.der"])
+    sh(["openssl", "ecparam", "-genkey", "-name", "prime256v1", "-outform", "DER",
+        "-out", "ec256_sec1.der"])
+    sh(["openssl", "genpkey", "-algorithm", "EC", "-pkeyopt", "ec_paramgen_curve:secp384r1",
+        "-outform", "DER", "-out", "ec384_pkcs8.der"])
+    sh(["openssl", "genpkey", "-algorithm", "ED25519", "-outform", "DER", "-out", "ed25519.der"])
+    return [
+        ("rsa_pkcs8.der", "RSA-2048 private key"),
+        ("rsa_pkcs1.der", "RSA-2048 private key"),
+        ("ec256_pkcs8.der", "EC secp256r1 private key"),
+        ("ec256_sec1.der", "EC secp256r1 private key"),
+        ("ec384_pkcs8.der", "EC secp384r1 private key"),
+        ("ed25519.der", "Ed25519 private key"),
+    ]
+
+
+def main():
+    binary = sys.argv[1] if len(sys.argv) > 1 else os.path.join(ROOT, "build", "mithril")
+    if not os.path.exists(binary):
+        print(f"FAIL: binary not found: {binary} (build first)")
+        return 1
+    if not shutil.which("openssl"):
+        print("SKIP: openssl not installed (needed to generate DER key fixtures)")
+        return 0
+
+    with tempfile.TemporaryDirectory() as d:
+        keys = gen_keys(d)
+
+        # One binary "firmware image": each key wrapped in non-text padding, PEM-less.
+        pad = bytes(range(256)) * 8
+        blob = bytearray()
+        expected = {}  # offset -> label
+        for fn, label in keys:
+            blob += pad
+            off = len(blob)
+            blob += open(os.path.join(d, fn), "rb").read()
+            expected[off] = label
+        blob += pad
+        fw = os.path.join(d, "firmware.bin")
+        open(fw, "wb").write(blob)
+
+        # Bait that must NOT fire: key-ish class names + a lone anchor + random.
+        neg = bytearray(pad)
+        neg += b"com.example.crypto.RSAPrivateKeyImpl loadDerPrivateKey PRIVATE KEY\x00"
+        neg += bytes([0x02, 0x01, 0x00, 0x30, 0xEE, 0xEE]) + bytes(range(256)) * 4
+        open(os.path.join(d, "negative.bin"), "wb").write(neg)
+
+        rep = json.loads(subprocess.check_output([binary, "-j", "--secrets", d]))
+        der = [h for h in rep["secrets"] if h["type"] == "der-private-key"]
+        fails = 0
+
+        by_off = {h["offset"]: h for h in der if h["path"] == "firmware.bin"}
+        for off, label in expected.items():
+            h = by_off.get(off)
+            if not h:
+                print(f"FAIL: no der-private-key at offset {off} (expected {label})")
+                fails += 1
+            elif h["label"] != label:
+                print(f"FAIL: offset {off}: label {h['label']!r} != expected {label!r}")
+                fails += 1
+            elif h.get("confidence_tier") != "structural":
+                print(f"FAIL: offset {off}: tier {h.get('confidence_tier')} != structural")
+                fails += 1
+
+        # Each key counted exactly once (PKCS#8 wrapper not double-reported with its
+        # nested PKCS#1) — one finding per embedded key.
+        fw_hits = [h for h in der if h["path"] == "firmware.bin"]
+        if len(fw_hits) != len(expected):
+            print(f"FAIL: expected {len(expected)} keys in firmware.bin, got {len(fw_hits)}")
+            fails += 1
+
+        if any(h["path"] == "negative.bin" for h in der):
+            print("FAIL: false positive in negative.bin (key-shaped bait matched)")
+            fails += 1
+
+        if fails == 0:
+            print(f"PASS: {len(fw_hits)} DER keys detected across encodings "
+                  f"(PKCS#8/PKCS#1/SEC1; RSA/EC/Ed25519), zero false positives")
+            return 0
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/unit_tests.cpp
+++ b/tests/unit/unit_tests.cpp
@@ -13,6 +13,7 @@
 #include "binver.hpp"
 #include "component.hpp"
 #include "credstore.hpp"
+#include "derkey.hpp"
 #include "cve.hpp"
 #include "osvindex.hpp"
 #include "sha256.hpp"
@@ -1172,6 +1173,79 @@ static void test_sha256() {
           "7ce100971f64e7001e8fe5a51973ecdfe1ced42befe7ee8d5fd6219506b5393c");
 }
 
+// ---- DER private-key scanner --------------------------------------------
+// kEcSec1: a real EC secp256r1 key in traditional SEC1 form (RFC 5915), DER.
+static const uint8_t kEcSec1[] = {
+    0x30, 0x77, 0x02, 0x01, 0x01, 0x04, 0x20, 0xE1, 0x2B, 0xF9, 0x74, 0x95,
+    0xFD, 0xA2, 0xFD, 0xA6, 0x18, 0x64, 0x56, 0x8D, 0xBE, 0xE4, 0xBF, 0x50,
+    0x6F, 0x83, 0xC7, 0x7E, 0xDF, 0x25, 0xA6, 0x82, 0x32, 0x1B, 0xF6, 0x33,
+    0x33, 0xB0, 0x93, 0xA0, 0x0A, 0x06, 0x08, 0x2A, 0x86, 0x48, 0xCE, 0x3D,
+    0x03, 0x01, 0x07, 0xA1, 0x44, 0x03, 0x42, 0x00, 0x04, 0x4B, 0xC0, 0xE5,
+    0x07, 0x22, 0x56, 0xD9, 0xFD, 0x48, 0x45, 0xD2, 0x41, 0x76, 0x9B, 0x5D,
+    0x95, 0x2B, 0xFE, 0x74, 0x8D, 0xCB, 0xA9, 0x32, 0x11, 0x55, 0xEB, 0xC5,
+    0x7C, 0x73, 0xAE, 0x71, 0x1F, 0x44, 0x1C, 0x1F, 0xA9, 0x1F, 0x69, 0xC7,
+    0xC1, 0xE4, 0x3E, 0x4B, 0x7B, 0x0A, 0x21, 0x60, 0x49, 0x2D, 0x63, 0x97,
+    0x3C, 0x53, 0xDF, 0x8B, 0xBA, 0xA0, 0x78, 0x30, 0x2A, 0x20, 0xAD, 0xE4,
+    0xEB,
+};
+// kEd25519: a real Ed25519 key in PKCS#8 form (RFC 8410), DER.
+static const uint8_t kEd25519[] = {
+    0x30, 0x2E, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06, 0x03, 0x2B, 0x65, 0x70,
+    0x04, 0x22, 0x04, 0x20, 0x73, 0xF1, 0x33, 0xEE, 0xEF, 0x15, 0x41, 0x6C,
+    0x69, 0xA8, 0xDC, 0x27, 0x70, 0x58, 0x81, 0x24, 0x06, 0x48, 0x2D, 0xEB,
+    0x81, 0x53, 0x21, 0x9A, 0xAE, 0x68, 0xFD, 0x35, 0x12, 0x89, 0x1D, 0x6C,
+};
+
+static void test_derkey() {
+    // Two real DER keys embedded in binary padding, no PEM wrapper — exactly the
+    // shape the text-anchored engine misses.
+    std::vector<uint8_t> buf;
+    auto pad = [&](size_t n) { for (size_t i = 0; i < n; ++i) buf.push_back(uint8_t(i * 7 + 1)); };
+    pad(500);
+    size_t ec_off = buf.size();
+    buf.insert(buf.end(), std::begin(kEcSec1), std::end(kEcSec1));
+    pad(300);
+    size_t ed_off = buf.size();
+    buf.insert(buf.end(), std::begin(kEd25519), std::end(kEd25519));
+    pad(500);
+
+    ft::Reader r(buf);
+    auto keys = ft::scan_der_private_keys(r);
+    CHECK(keys.size() == 2);
+    bool ec_ok = false, ed_ok = false;
+    for (const auto& k : keys) {
+        CHECK(k.type == "der-private-key");
+        CHECK(k.category == "secret");
+        CHECK(k.confidence == static_cast<uint8_t>(ft::Confidence::Structural));
+        if (k.offset == ec_off && k.size == sizeof(kEcSec1) && k.label == "EC secp256r1 private key")
+            ec_ok = true;
+        if (k.offset == ed_off && k.size == sizeof(kEd25519) && k.label == "Ed25519 private key")
+            ed_ok = true;
+    }
+    CHECK(ec_ok);
+    CHECK(ed_ok);
+
+    // Negatives: key-ish class names and a lone version+SEQUENCE run must not fire.
+    {
+        std::string s = "org.bouncycastle.crypto.params.RSAPrivateKeyStructure loadPrivateKey";
+        std::vector<uint8_t> n(s.begin(), s.end());
+        ft::Reader nr(n);
+        CHECK(ft::scan_der_private_keys(nr).empty());
+    }
+    {
+        // The PKCS#8 anchor bytes but no valid key structure after them.
+        std::vector<uint8_t> n = {0x00, 0x02, 0x01, 0x00, 0x30, 0xFF, 0xFF, 0xFF, 0xFF, 0x00};
+        ft::Reader nr(n);
+        CHECK(ft::scan_der_private_keys(nr).empty());
+    }
+    // Truncated key (last 5 bytes cut) must not match and must not crash.
+    {
+        std::vector<uint8_t> t(std::begin(kEcSec1), std::end(kEcSec1) - 5);
+        ft::Reader tr(t);
+        CHECK(ft::scan_der_private_keys(tr).empty());
+    }
+}
+
 int main() {
     test_ahocorasick();
     test_entropy();
@@ -1182,6 +1256,7 @@ int main() {
     test_validators_github_crc();
     test_validators_jwt();
     test_validators_pem();
+    test_derkey();
     test_glob();
     test_path_rules();
     test_metadata();


### PR DESCRIPTION
## Problem

mithril's secrets pass is text-anchored — it hunts PEM armor
(`-----BEGIN … PRIVATE KEY-----`), `AKIA…`, `api_key=` and the like over
*text-ish* regions only. Firmware images routinely embed private keys as **raw
DER** — PKCS#8 `PrivateKeyInfo`, PKCS#1 `RSAPrivateKey`, or SEC1 `ECPrivateKey`
— with **no PEM wrapper and no adjacent keyword**. There is nothing for the
anchors to hit, and the bytes live in a region the text-ish gate skips, so
these keys are invisible to the current scan. A fleet-shared signing or TLS
key baked into an image is exactly the high-impact finding worth surfacing.

## Approach

New `src/derkey.cpp`:

- Aho-Corasick over a few length-independent byte anchors that begin a
  private-key `SEQUENCE`'s content (the version INTEGER + the tag that follows).
- At each candidate, recover the enclosing `SEQUENCE` header and run a full
  ASN.1 DER tag/length walk to confirm a **complete, well-formed** private key
  and name its algorithm and size.
- **Structural** validation — not pattern matching — is what rejects the false
  positives (class names, CA-certificate stores, dictionary words) that defeat
  text sweeps. Anything that doesn't parse to a valid key structure with a known
  algorithm OID and self-consistent lengths is dropped.
- Dependency-free (no crypto library); every read is bounds-checked through
  `Reader`, so a hostile length just fails the parse. Overlapping matches are
  deduplicated, so a PKCS#8 wrapper and the PKCS#1 key nested in its OCTET
  STRING count once.

Recognizes RSA (PKCS#1 + PKCS#8), EC (SEC1 + PKCS#8: secp256r1/384r1/521r1/
256k1), and Ed25519 / Ed448 / X25519 / X448. Each is reported at the
`structural` tier as `der-private-key` (category `secret`).

Wired into the secrets pass in `walk.cpp` as a raw whole-buffer scan — the
text-ish gate deliberately does not apply to binary DER.

## Testing

- **Unit** (`tests/unit`): real EC-SEC1 and Ed25519 keys embedded in binary
  padding are found with correct labels/offsets/size; class-name bait, a lone
  anchor, and a truncated key produce nothing.
- **Integration** (`tests/test_der_keys.py`): openssl-generates RSA/EC/Ed25519
  keys in PKCS#8/PKCS#1/SEC1, embeds them PEM-less in a binary blob, and asserts
  each is detected exactly once with the right label and zero false positives on
  bait. Self-skips if openssl is absent.
- Validated against real firmware partition images that carry embedded DER
  keys: every key the scanner reports loads as a valid private key via
  `openssl pkey -inform DER` (no structural false positives), and it surfaced
  keys a prior text/PEM-only sweep had missed.

`mithril_unit` (now 297 checks) and `tests/test_secrets.py` pass unchanged.
