### PR TITLE
licenses: show file locations (--license-paths + JSON paths array)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ mithril --sbom -C out/ <dir>  # SBOM only -> out/sbom.cdx.json + out/sbom.spdx.j
 mithril --cve <dir>           # match components against the local mirror (offline)
 mithril --cve --kernel-cves-all <dir>  # also list every kernel.org CVE for the kernel version (opt-in)
 mithril --licenses <dir>      # licenses only
+mithril --license-paths <dir> # licenses, with each license's file locations listed
 mithril --rules my.json <dir> # add user-defined rules (docs/user-rules.md)
 mithril --fetch-db            # FIRST RUN: download the CVE mirror (a networked command)
 mithril --fetch-db --with-kernel-feed  # also fetch the optional full kernel.org CVE feed
@@ -72,7 +73,7 @@ Build it once either way; every scan after that is offline. See `docs/cve-join.m
 - **secrets**: credential and key material in file content (cloud keys, tokens, JWTs, private keys, high-entropy `KEY=…` values). `/etc/shadow` and `htpasswd` hashes are classified with weak-algorithm and empty-password flags, and credential/crypto/config files are flagged by path.
 - **sbom**: components and versions from package databases, language manifests, binary version strings, libc filenames, and the kernel banner, keyed on purl (with CPE co-derived), emitted as CycloneDX and SPDX.
 - **cve**: the SBOM joined against the local OSV + NVD/CPE mirror, plus the curated kernel-CVE checklist, annotated with KEV and EPSS.
-- **licenses**: SPDX identification from `SPDX-License-Identifier` tags and LICENSE/COPYING/NOTICE text.
+- **licenses**: SPDX identification from `SPDX-License-Identifier` tags and LICENSE/COPYING/NOTICE text. Human output summarizes by id and count; `--license-paths` lists each license's file locations, and JSON always carries the full `paths` array.
 
 File-type identification, extraction, and embedded key/certificate *file* signatures are moria's job; mithril reads content, it does not unpack. How discovery works is documented in `docs/engine-design.md`.
 

--- a/src/human.cpp
+++ b/src/human.cpp
@@ -41,7 +41,7 @@ std::string clip(const std::string& s, size_t w) {
 }  // namespace
 
 std::string emit_report_human(const Report& rep, const Passes& passes, const std::string& footer,
-                              bool color) {
+                              bool color, bool license_paths) {
     Ansi a{color};
     std::string o;
 
@@ -435,35 +435,76 @@ std::string emit_report_human(const Report& rep, const Passes& passes, const std
     // ---- licenses (aggregated by id) ----
     if (passes.licenses) {
         if (passes.secrets || passes.sbom || passes.cve) o += "\n";
-        std::vector<std::pair<std::string, size_t>> agg;  // id -> count, first-seen order
+        // Group findings by license id, preserving first-seen order; each group
+        // keeps its file paths so --license-paths can list them.
+        std::vector<std::pair<std::string, std::vector<std::string>>> groups;
         for (const auto& h : rep.licenses) {
-            auto it = std::find_if(agg.begin(), agg.end(),
-                                   [&](const auto& p) { return p.first == h.finding.type; });
-            if (it == agg.end()) agg.push_back({h.finding.type, 1});
-            else it->second++;
+            auto it = std::find_if(groups.begin(), groups.end(),
+                                   [&](const auto& g) { return g.first == h.finding.type; });
+            if (it == groups.end()) groups.push_back({h.finding.type, {h.path}});
+            else it->second.push_back(h.path);
         }
-        std::sort(agg.begin(), agg.end(), [](const auto& a, const auto& b) {
-            if (a.second != b.second) return a.second > b.second;
-            return a.first < b.first;
+        std::sort(groups.begin(), groups.end(), [](const auto& x, const auto& y) {
+            if (x.second.size() != y.second.size()) return x.second.size() > y.second.size();
+            return x.first < y.first;
         });
         o += a.bold();
-        o += std::to_string(agg.size());
-        o += agg.size() == 1 ? " license" : " licenses";
+        o += std::to_string(groups.size());
+        o += groups.size() == 1 ? " license" : " licenses";
         o += a.reset();
         o += "\n";
-        if (!agg.empty()) {
+        if (!groups.empty()) {
             size_t wid = 7;
-            for (const auto& p : agg) wid = std::max(wid, p.first.size());
-            wid = std::min<size_t>(wid, 24);
+            for (const auto& g : groups) wid = std::max(wid, g.first.size());
+            // SPDX ids are short and bounded, and compound expressions ("A OR B",
+            // "A WITH exception") carry meaning in the leading term that a tight
+            // clip would drop. Allow a wide column (fits every realistic id) so
+            // the cap only ever guards against a degenerate value.
+            wid = std::min<size_t>(wid, 48);
             o += "\n";
-            for (const auto& p : agg) {
-                o += "  ";
-                o += a.cyan();
-                pad(o, clip(p.first, wid), wid);
-                o += a.reset();
-                o += "  ";
+            if (license_paths) {
+                // Detail view: one row per (license, file), grouped by id, in the
+                // notable-files layout. A single very common license is capped;
+                // -j always carries the complete set.
+                constexpr size_t kCap = 20;
+                for (const auto& g : groups) {
+                    size_t shown = std::min(g.second.size(), kCap);
+                    for (size_t i = 0; i < shown; ++i) {
+                        o += "  ";
+                        o += a.cyan();
+                        pad(o, clip(g.first, wid), wid);
+                        o += a.reset();
+                        o += "  ";
+                        o += g.second[i];
+                        o += "\n";
+                    }
+                    if (g.second.size() > kCap) {
+                        o += "  ";
+                        for (size_t i = 0; i < wid; ++i) o += ' ';  // align under the paths
+                        o += "  ";
+                        o += a.dim();
+                        o += "... and " + std::to_string(g.second.size() - kCap) +
+                             " more (use -j for the complete list)";
+                        o += a.reset();
+                        o += "\n";
+                    }
+                }
+            } else {
+                // Summary view (default): id + count.
+                for (const auto& g : groups) {
+                    o += "  ";
+                    o += a.cyan();
+                    pad(o, clip(g.first, wid), wid);
+                    o += a.reset();
+                    o += "  ";
+                    o += a.dim();
+                    o += "x" + std::to_string(g.second.size());
+                    o += a.reset();
+                    o += "\n";
+                }
+                o += "\n";
                 o += a.dim();
-                o += "x" + std::to_string(p.second);
+                o += "  Run --license-paths to show where each license was found.";
                 o += a.reset();
                 o += "\n";
             }

--- a/src/human.hpp
+++ b/src/human.hpp
@@ -12,7 +12,10 @@
 
 namespace ft {
 
+// `license_paths` expands the license section from the aggregated id+count
+// summary to one row per (license, file), grouped by id (the "--license-paths"
+// flag). JSON (-j) always carries every path regardless of this.
 std::string emit_report_human(const Report& rep, const Passes& passes, const std::string& footer,
-                              bool color);
+                              bool color, bool license_paths = false);
 
 }  // namespace ft

--- a/src/json.cpp
+++ b/src/json.cpp
@@ -309,26 +309,28 @@ std::string emit_report_json(const Report& rep, const Passes& passes) {
     }
 
     if (passes.licenses) {
-        // Aggregate by license id: count + an example path + best tier.
-        struct Agg { size_t count = 0; std::string example, tier; uint8_t conf = 0; };
+        // Aggregate by license id: count + every distinct file path + best tier.
+        // JSON is the machine view, so it always carries the complete path list
+        // (the human --license-paths flag does not gate this).
+        struct Agg { std::vector<std::string> paths; std::string tier; uint8_t conf = 0; };
         std::vector<std::pair<std::string, Agg>> agg;
         for (const auto& h : rep.licenses) {
             auto it = std::find_if(agg.begin(), agg.end(),
                                    [&](const auto& p) { return p.first == h.finding.type; });
             if (it == agg.end()) {
-                agg.push_back({h.finding.type, {1, h.path, h.finding.confidence_tier,
-                                                h.finding.confidence}});
+                agg.push_back({h.finding.type,
+                               {{h.path}, h.finding.confidence_tier, h.finding.confidence}});
             } else {
-                it->second.count++;
+                it->second.paths.push_back(h.path);
                 if (h.finding.confidence > it->second.conf) {
                     it->second.conf = h.finding.confidence;
                     it->second.tier = h.finding.confidence_tier;
-                    it->second.example = h.path;
                 }
             }
         }
         std::sort(agg.begin(), agg.end(), [](const auto& a, const auto& b) {
-            if (a.second.count != b.second.count) return a.second.count > b.second.count;
+            if (a.second.paths.size() != b.second.paths.size())
+                return a.second.paths.size() > b.second.paths.size();
             return a.first < b.first;
         });
         o += ",\"licenses\":[";
@@ -337,10 +339,16 @@ std::string emit_report_json(const Report& rep, const Passes& passes) {
             o += "{";
             bool first = true;
             kv_str(o, "license", agg[i].first, first);
-            kv_num(o, "count", agg[i].second.count, first);
+            kv_num(o, "count", agg[i].second.paths.size(), first);
             kv_str(o, "confidence_tier", agg[i].second.tier, first);
-            kv_str(o, "example_path", agg[i].second.example, first);
-            o += "}";
+            o += ",\"paths\":[";
+            for (size_t p = 0; p < agg[i].second.paths.size(); ++p) {
+                if (p) o += ",";
+                o += "\"";
+                json_escape(o, agg[i].second.paths[p]);
+                o += "\"";
+            }
+            o += "]}";
         }
         o += "]";
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -52,6 +52,8 @@ void print_help(std::FILE* out, const char* prog, bool color) {
                  "      --sbom          Inventory software components and versions\n"
                  "      --cve           Match components against known vulnerabilities\n"
                  "      --licenses      Identify open-source licenses\n"
+                 "      --license-paths  List the file locations of each license, not just\n"
+                 "                       a count (human output; implies --licenses)\n"
                  "  -A, --all           Run every pass (the default when none is selected)\n"
                  "      --kernel-cves-all  List every CVE for the detected kernel version, not\n"
                  "                         just the curated set (needs the kernel feed; implies --cve)\n"
@@ -89,6 +91,7 @@ int main(int argc, char** argv) {
     bool fetch_db = false;
     bool dump_kconfig = false;
     bool kernel_cves_all = false;
+    bool license_paths = false;
     bool with_kernel_feed = false;
     Passes passes;
     bool have_path = false;
@@ -134,6 +137,8 @@ int main(int argc, char** argv) {
             dump_kconfig = true;
         } else if (!end_of_opts && std::strcmp(a, "--kernel-cves-all") == 0) {
             kernel_cves_all = true;
+        } else if (!end_of_opts && std::strcmp(a, "--license-paths") == 0) {
+            license_paths = true;
         } else if (!end_of_opts && std::strcmp(a, "--with-kernel-feed") == 0) {
             with_kernel_feed = true;
         } else if (!end_of_opts && std::strcmp(a, "--rules") == 0 && i + 1 < argc) {
@@ -179,6 +184,8 @@ int main(int argc, char** argv) {
 
     // --kernel-cves-all is a CVE-pass feature; make sure that pass runs.
     if (kernel_cves_all) passes.cve = true;
+    // --license-paths expands the license section; make sure that pass runs.
+    if (license_paths) passes.licenses = true;
 
     // No pass selected -> run them all (like a bare `mithril <tree>`).
     if (!passes.any()) passes.all();
@@ -337,7 +344,7 @@ int main(int argc, char** argv) {
         std::snprintf(foot, sizeof(foot), "Scanned %zu file%s (%zu bytes) in %.3f s",
                       rep.file_count, rep.file_count == 1 ? "" : "s", rep.bytes_scanned, secs);
         bool color = isatty(fileno(stdout)) && !std::getenv("NO_COLOR");
-        std::string h = emit_report_human(rep, impl, foot, color);
+        std::string h = emit_report_human(rep, impl, foot, color, license_paths);
         std::fwrite(h.data(), 1, h.size(), stdout);
     }
 

--- a/tests/test_licenses.py
+++ b/tests/test_licenses.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 """test_licenses.py — integration test for the license pass.
 
-Builds a tree with a COPYING file (GPL-2.0 text), a NOTICE (Apache-2.0), and a
-source file carrying an SPDX tag, runs `mithril -j --licenses`, and asserts the
-licenses are identified with the right basis.
+Builds a tree with a COPYING file (GPL-2.0 text), a NOTICE (Apache-2.0), and two
+source files carrying the same SPDX tag, runs `mithril -j --licenses`, and
+asserts the licenses are identified with the right basis. Also checks the
+`paths` array (every file location per license) in JSON and the human-mode
+`--license-paths` expansion vs the default count summary (issue #3).
 
 Usage: tests/test_licenses.py [path/to/mithril]   (default: build/mithril)
 """
@@ -29,8 +31,12 @@ def main():
             f.write("GNU GENERAL PUBLIC LICENSE\n  Version 2, June 1991\n ...body...\n")
         with open(os.path.join(d, "NOTICE"), "w") as f:
             f.write("Apache License\n Version 2.0, January 2004\n http://www.apache.org/\n")
+        # Same SPDX tag in two files -> the license must aggregate to count 2
+        # with both paths.
         with open(os.path.join(d, "src", "main.c"), "w") as f:
             f.write("// SPDX-License-Identifier: MIT\nint main(void){return 0;}\n")
+        with open(os.path.join(d, "src", "util.c"), "w") as f:
+            f.write("// SPDX-License-Identifier: MIT\nint util(void){return 1;}\n")
 
         out = subprocess.check_output([binary, "-j", "--licenses", d], stderr=subprocess.DEVNULL)
         rep = json.loads(out)
@@ -49,9 +55,45 @@ def main():
             print(f"FAIL: GPL-2.0 (license file) should be structural: {lic.get('GPL-2.0')}")
             fails += 1
 
+        # JSON carries every file location (issue #3): `paths` array, count-consistent,
+        # and the old `example_path` field is gone.
+        mit = lic.get("MIT", {})
+        if "example_path" in mit:
+            print(f"FAIL: example_path should be removed from JSON: {mit}")
+            fails += 1
+        mit_paths = mit.get("paths")
+        if not isinstance(mit_paths, list) or mit.get("count") != len(mit_paths):
+            print(f"FAIL: MIT paths array missing or count-inconsistent: {mit}")
+            fails += 1
+        elif sorted(mit_paths) != ["src/main.c", "src/util.c"]:
+            print(f"FAIL: MIT paths {mit_paths} != both source files")
+            fails += 1
+
+        # Human default: counts + the hint, no file paths printed.
+        human = subprocess.check_output([binary, "--licenses", d],
+                                        stderr=subprocess.DEVNULL).decode()
+        if "src/main.c" in human or "src/util.c" in human:
+            print("FAIL: default human output should not print file paths")
+            fails += 1
+        if "--license-paths" not in human:
+            print("FAIL: default human output should hint at --license-paths")
+            fails += 1
+
+        # Human --license-paths: the actual locations appear, hint gone.
+        paths_out = subprocess.check_output([binary, "--license-paths", d],
+                                            stderr=subprocess.DEVNULL).decode()
+        for p in ("src/main.c", "src/util.c"):
+            if p not in paths_out:
+                print(f"FAIL: --license-paths output missing {p}")
+                fails += 1
+        # MIT id should appear on two rows (once per file) in the detail view.
+        if paths_out.count("MIT") < 2:
+            print("FAIL: --license-paths should show MIT once per file")
+            fails += 1
+
         if fails == 0:
-            print("PASS: GPL-2.0 + Apache-2.0 (license files, structural) and MIT (SPDX tag, "
-                  "validated) identified")
+            print("PASS: GPL-2.0 + Apache-2.0 (files, structural) and MIT x2 (SPDX tag, "
+                  "validated) identified; JSON paths array, --license-paths locations")
             return 0
         return 1
 


### PR DESCRIPTION
Fixes #3.

The license section listed each license id with a count but never said *where* each was found. As the reporter noted, that is not much use on its own, and the "notable files" section already shows paths.

## Human output

- **Default is unchanged:** the compact `id  xN` summary, now followed by a one-line hint pointing at `--license-paths` (same pattern as the kernel-CVE summary pointing at `--kernel-cves-all`).
- **New `--license-paths` flag** expands the section to one row per `(license, file)`, grouped by id, in the notable-files layout. A single very common license is capped at 20 rows with a `... N more (use -j)` line; `-j` always carries the full set. The flag implies `--licenses`.
- **Widened the id column** cap from 24 to 48. SPDX ids are short and bounded, and compound expressions (`A OR B`, `A WITH exception`) carry meaning in the leading term that the old cap clipped away (`GPL-2.0-or-later OR BSD-2-Clause` was showing as `...later OR BSD-2-Clause`).

```
3 licenses

  GPL-2.0-only                      etc/init.d/bootcount
  GPL-2.0-only                      usr/bin/owut
  GPL-2.0-only                      usr/share/ucode/utils/argparse.uc
  GPL-2.0-or-later OR BSD-2-Clause  lib/preinit/75_rootfs_prepare
  GPL-2.0-or-later OR MIT           lib/upgrade/tar.sh
```

## JSON output

- Each aggregated license now carries a `paths` array with every distinct file location (`count` is its length). JSON is the machine view, so it is always complete and not gated by the human flag.
- Dropped the old `example_path` field (a single representative path); `paths[0]` supersedes it.

```json
{ "license": "GPL-2.0-only", "count": 3, "confidence_tier": "validated",
  "paths": ["etc/init.d/bootcount", "usr/bin/owut", "usr/share/ucode/utils/argparse.uc"] }
```

## Tests

`test_licenses.py`: the same SPDX tag in two files now asserts count 2 with both paths; the paths array is count-consistent; `example_path` is gone; the default human view prints no paths but hints at the flag; `--license-paths` lists the locations. Full suite green, ASan/UBSan clean (332 unit checks). Verified against the OpenWrt One image from the report.