### PR TITLE
ci: build+test, sanitizers, and fuzz-smoke on every PR and push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,76 @@
+name: ci
+
+# Build + test on every PR and on pushes to master. Complements release.yml
+# and update-db.yml. Three jobs:
+#   build-test  - gcc and clang, Release, the full unit + integration suite
+#   sanitizers  - ASan + UBSan build, same suite (memory safety on hostile input)
+#   fuzz-smoke  - a short libFuzzer run of the secrets target
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test:
+    name: build + test (${{ matrix.cc }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { cc: gcc, cxx: g++ }
+          - { cc: clang, cxx: clang++ }
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install build deps
+        # mithril links only pthreads (its own DEFLATE, no codec libs) and the
+        # integration tests are self-contained, so no filesystem/codec packages.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends cmake g++ clang python3
+      - name: Build + run the suite
+        env:
+          CC: ${{ matrix.cc }}
+          CXX: ${{ matrix.cxx }}
+        run: bash tests/run.sh
+
+  sanitizers:
+    name: asan + ubsan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends cmake clang python3
+      - name: Build + run the suite under ASan/UBSan
+        env:
+          CC: clang
+          CXX: clang++
+          EXTRA_CMAKE: -DMT_SANITIZE=ON
+          ASAN_OPTIONS: abort_on_error=1:detect_leaks=0
+          UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1
+        run: bash tests/run.sh
+
+  fuzz-smoke:
+    name: fuzz smoke (60s)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install clang
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends clang
+      - name: Build the libFuzzer target
+        run: bash fuzz/build.sh
+      - name: Fuzz 60s
+        run: |
+          mkdir -p fuzz/corpus
+          ./fuzz/fuzz_secrets -max_total_time=60 -rss_limit_mb=4096 fuzz/corpus

--- a/fuzz/build.sh
+++ b/fuzz/build.sh
@@ -5,11 +5,14 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 CXX=${CXX:-clang++}
+# Compile the whole src tree except main.cpp (libFuzzer supplies its own main),
+# so the fuzz build never drifts out of sync when a new module is added (a
+# hardcoded list previously dropped kconfig_infer.cpp and failed to link).
+mapfile -t SRCS < <(find src -name '*.cpp' ! -name 'main.cpp' | sort)
 "$CXX" -std=c++20 -O1 -g \
     -fsanitize=fuzzer,address,undefined -fno-omit-frame-pointer \
     -I src \
-    src/ahocorasick.cpp src/validators.cpp src/rules_builtin.cpp src/engine.cpp \
-    src/credstore.cpp src/binver.cpp src/filever.cpp src/inflate.cpp src/kconfig.cpp src/kernelcve.cpp src/version.cpp src/langmanifest.cpp src/rpm.cpp src/license.cpp src/sbom.cpp fuzz/fuzz_secrets.cpp \
+    "${SRCS[@]}" fuzz/fuzz_secrets.cpp \
     -o fuzz/fuzz_secrets
 
 echo "built fuzz/fuzz_secrets — run: ./fuzz/fuzz_secrets -max_total_time=60"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -7,7 +7,9 @@ cd "$(dirname "$0")/.."
 BUILD=${BUILD:-build}
 
 echo "== configure + build =="
-cmake -S . -B "$BUILD" -DCMAKE_BUILD_TYPE=Release >/dev/null
+# EXTRA_CMAKE lets CI run the whole suite under sanitizers (EXTRA_CMAKE=-DMT_SANITIZE=ON)
+# without duplicating the test list here.
+cmake -S . -B "$BUILD" -DCMAKE_BUILD_TYPE=Release ${EXTRA_CMAKE:-} >/dev/null
 cmake --build "$BUILD" -j >/dev/null
 
 echo "== unit tests =="


### PR DESCRIPTION
`release.yml` / `update-db.yml` don't check a PR, so nothing did. Adds `.github/workflows/ci.yml` (runs on `pull_request` + push to `master`), so it runs on this PR itself.

## Jobs
- **build-test** — gcc **and** clang, Release, the full unit + integration suite via `tests/run.sh`. mithril links only pthreads (its own DEFLATE, no codec libs) and the integration tests are self-contained, so no extra packages are needed.
- **sanitizers** — the same suite under ASan + UBSan (`-DMT_SANITIZE=ON`), wired through a new `EXTRA_CMAKE` hook in `tests/run.sh` so the test list isn't duplicated. Memory safety on the hostile-input parser is the thing most worth catching here.
- **fuzz-smoke** — builds the secrets libFuzzer target and runs 60 s.

## Also fixes the fuzz build
`fuzz/build.sh` had a hardcoded source list that had drifted (it dropped `kconfig_infer.cpp`, so the target failed to link). It now globs the whole `src/` tree except `main.cpp`, so it can't drift out of sync again.

Validated locally: `tests/run.sh` green on gcc + clang; the suite green under `-DMT_SANITIZE=ON`; the fuzzer builds and smokes clean.

## Follow-ups (same as the sibling repo)
CodeQL, OSS-Fuzz enrollment, `-Werror`, clang-tidy (advisory), action SHA-pinning + Dependabot, and branch protection requiring these checks before merge.