### PR TITLE
cve: gate the default human view to foothold-worthy findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ mithril --secrets <dir>       # secrets only
 mithril --sbom -C out/ <dir>  # SBOM only -> out/sbom.cdx.json + out/sbom.spdx.json
 mithril --cve <dir>           # match components against the local mirror (offline)
 mithril --cve --kernel-cves-all <dir>  # also list every kernel.org CVE for the kernel version (opt-in)
+mithril --cve --component-cves-all <dir>  # human view: list every component CVE, not just high-signal (opt-in)
 mithril --licenses <dir>      # licenses only
 mithril --license-paths <dir> # licenses, with each license's file locations listed
 mithril --rules my.json <dir> # add user-defined rules (docs/user-rules.md)
@@ -72,7 +73,7 @@ Build it once either way; every scan after that is offline. See `docs/cve-join.m
 
 - **secrets**: credential and key material in file content (cloud keys, tokens, JWTs, private keys, high-entropy `KEY=…` values). `/etc/shadow` and `htpasswd` hashes are classified with weak-algorithm and empty-password flags, and credential/crypto/config files are flagged by path.
 - **sbom**: components and versions from package databases, language manifests, binary version strings, libc filenames, and the kernel banner, keyed on purl (with CPE co-derived), emitted as CycloneDX and SPDX.
-- **cve**: the SBOM joined against the local OSV + NVD/CPE mirror, plus the curated kernel-CVE checklist, annotated with KEV and EPSS.
+- **cve**: the SBOM joined against the local OSV + NVD/CPE mirror, plus the curated kernel-CVE checklist, annotated with KEV and EPSS. The default human view shows only foothold-worthy component CVEs (on CISA KEV, or Critical, or a hard High/Critical floor of CVSS >= 7.0 with EPSS traction, low attack complexity, and real impact or a trending remote DoS), sorted worst-first; it drops Mediums, local DoS, and the high-complexity crypto class. `--component-cves-all` lists them all. JSON always carries the complete set plus a `component_cve_scan` summary.
 - **licenses**: SPDX identification from `SPDX-License-Identifier` tags and LICENSE/COPYING/NOTICE text. Human output summarizes by id and count; `--license-paths` lists each license's file locations, and JSON always carries the full `paths` array.
 
 File-type identification, extraction, and embedded key/certificate *file* signatures are moria's job; mithril reads content, it does not unpack. How discovery works is documented in `docs/engine-design.md`.

--- a/docs/cve-join.md
+++ b/docs/cve-join.md
@@ -179,3 +179,74 @@ is annotated with `kev` (on the known-exploited list) and `epss` (0..1 exploit p
 context only and never change whether a finding is reported: for IoT especially, KEV skews to enterprise
 IT and misses kernel LPEs, so it must not be a gate. The human view tags a row `[KEV]` and `epss=0.NN`
 (shown when ≥ 0.10).
+
+## Human-view high-signal gate (display only, JSON stays complete)
+
+The default human output is meant for a manual pentester triaging by impact, not a compliance dump. A
+firmware image pins old C libraries, so a flat join returns dozens to hundreds of component CVEs of every
+severity (busybox alone brought 20 on one sample) with no ranking. The default human view therefore shows
+only **high-signal** component CVEs and sorts them worst-first; `--component-cves-all` prints the full
+list.
+
+A component CVE is high-signal if:
+
+- it is on the **CISA KEV** catalog (`kev`) — exploited in the wild — **unconditional**; or
+- its **CVSS base score is ≥ 9.0** (Critical) — any shape — **unconditional**; or
+- it clears **all** of a hard floor and quality test below Critical:
+  - **CVSS base score ≥ 7.0** (a hard High/Critical floor — Mediums never show), AND
+  - **EPSS ≥ 0.10** (exploit traction), AND
+  - **`AC:L`** (low attack complexity — drops the MITM/side-channel crypto class), AND
+  - **either** a real confidentiality/integrity impact (any `C` or `I` above None) **or** a *remote* DoS
+    (`AV:N`, availability-only) that is trending, **`EPSS ≥ 0.70`**. Local/adjacent/physical DoS never shows.
+
+The base score is recomputed in `cvss_base_score()` (cve.cpp) straight from the stored vector, for **both
+CVSS v3.0/v3.1 and CVSS v2** (`cvss3_base_score` / `cvss2_base_score`), so the hard floor judges old CVEs
+too instead of hiding them for lack of a v3 vector (on one large distro-based image 45 of 235 v2-only CVEs
+are genuinely High/Critical). An unparseable/empty vector scores −1 and is dropped by the floor (KEV still
+surfaces it).
+The gate is `cve_is_high_signal()`; thresholds live as `kHighSignalCvss` (9.0), `kHighFloorCvss` (7.0),
+`kHighSignalEpss` (0.10), `kDosEpss` (0.70) in cve.hpp.
+
+**Why the hard floor and the extra quality test.** EPSS covers essentially every published CVE, so
+presence is meaningless — only a threshold gates. But even a threshold *overrates* the wrong bugs for a
+firmware foothold: old libraries (openssl above all) accumulate famous crypto and DoS CVEs that score high
+on EPSS because they are internet-scanned, not because they shell a device. On one openssl-heavy image a
+pure EPSS threshold surfaced 41 CVEs, most of them availability-only DoS or MITM/side-channel crypto
+(SWEET32 EPSS 0.96, DROWN 0.82, padding-oracle 0.89) — none a foothold. The gate cuts them by CVSS-vector
+semantics:
+
+- **hard 7.0 floor** — a pentester wants Highs and Criticals; Mediums (a 5.3 X.509 overread, a 6.5 hang)
+  are noise no matter how they trend on EPSS.
+- **`AC:H`** (high complexity — MITM, a race, massive traffic, a specific config): the crypto-attack class,
+  dropped.
+- **availability-only** (`C:N` and `I:N`) is a DoS. DoS is not categorically noise on IoT — a *remote*
+  network DoS against the device is a valid finding — but a *local* DoS is not, and a single old library
+  brings dozens of remote-DoS CVEs, so a remote DoS shows only when genuinely trending (`EPSS ≥ 0.70`).
+  This keeps CVE-2022-0778 (BN_mod_sqrt hang, EPSS 0.73) and drops the long tail of 0.1–0.5 TLS hangs.
+
+KEV and Critical CVSS stay **unconditional**. Effect on representative firmware images: an OpenSSL-heavy
+image 41 → 9, another embedded image 18 → 14, a large distro-based server image 175 → 35, a consumer
+router image 87 → 54.
+
+**The ceiling of vector-based filtering (known limitation).** The CVSS vector describes impact and
+complexity, not weakness *class*, so two cases leak:
+
+- a memory-corruption bug NVD conservatively scored availability-only (e.g. zlib CVE-2018-25032, a heap
+  corruption marked `A:H`) is dropped as "DoS", a false negative;
+- a pure crypto weakness that happens to carry `C:H`/`AC:L` (e.g. SWEET32 CVE-2016-2183) survives, a false
+  positive.
+
+The precise fix is **CWE-class filtering**: mirror each CVE's CWE (`weaknesses[]` from the NVD JSON) and
+gate on the weakness type — keep CWE-787/122/121/416/415/190/134/78/77/94/22/502/287/306/862/863
+(memory-corruption / injection / auth), suppress CWE-327/326/310/295/347/200 (broken crypto / cert / sig /
+info-leak) on the EPSS arm. That keeps the zlib corruption (it is CWE-787) *and* drops SWEET32 (CWE-327),
+which the vector heuristic cannot. It needs a mirror-format bump (OSV carries CWE unreliably, so OSV-only
+matches stay unclassified → kept). Deferred until the vector heuristic proves insufficient in practice.
+
+**This is a display filter, not a reporting gate.** The JSON `cves` array is always the complete join —
+nothing is dropped — and a `component_cve_scan` object (`total` / `high_signal` / `hidden` / `gate`) makes
+the human triage set machine-readable. The hard floor is deliberately blunt: a manual pentester triages
+Highs and Criticals, and anything below 7.0 (Terrapin CVE-2023-48795 at 5.9 included) goes to
+`--component-cves-all` or the JSON, not the default view. KEV is the one override that ignores the floor,
+so an actively-exploited Medium still shows. Kernel CVEs are gated separately (curated vs.
+`--kernel-cves-all` feed) and are unaffected by this component gate.

--- a/src/cve.cpp
+++ b/src/cve.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cmath>
 #include <cstdio>
 #include <string_view>
 
@@ -140,6 +141,111 @@ int cvss_rank(const std::string& v) {
     return 0;
 }
 }  // namespace
+
+// One base-metric value char from any CVSS vector, v2 ("AV:N/AC:L/Au:N/...") or
+// v3.x ("CVSS:3.1/AV:N/..."); the leading "CVSS:3.x" token is skipped naturally
+// since we never query the "CVSS" key. Returns 0 if the metric is absent.
+static char cvss_metric(const std::string& v, std::string_view key) {
+    size_t i = 0;
+    while (i < v.size()) {
+        size_t slash = v.find('/', i);
+        std::string_view tok(v.data() + i, (slash == std::string::npos ? v.size() : slash) - i);
+        size_t colon = tok.find(':');
+        if (colon != std::string_view::npos && colon + 1 < tok.size() && tok.substr(0, colon) == key)
+            return tok[colon + 1];
+        if (slash == std::string::npos) break;
+        i = slash + 1;
+    }
+    return 0;
+}
+
+// CVSS v3.0/v3.1 base score (spec arithmetic). v3.0 uses the same weights and an
+// equivalent roundup for our purposes. Returns -1.0 on an incomplete vector.
+static double cvss3_base_score(const std::string& vector) {
+    char AV = cvss_metric(vector, "AV"), AC = cvss_metric(vector, "AC");
+    char PR = cvss_metric(vector, "PR"), UI = cvss_metric(vector, "UI");
+    char S = cvss_metric(vector, "S"), C = cvss_metric(vector, "C");
+    char I = cvss_metric(vector, "I"), A = cvss_metric(vector, "A");
+    if (!AV || !AC || !PR || !UI || !S || !C || !I || !A) return -1.0;
+    const bool changed = (S == 'C');
+    double av = AV == 'N' ? 0.85 : AV == 'A' ? 0.62 : AV == 'L' ? 0.55 : AV == 'P' ? 0.20 : -1;
+    double ac = AC == 'L' ? 0.77 : AC == 'H' ? 0.44 : -1.0;
+    double pr = PR == 'N' ? 0.85
+                : PR == 'L' ? (changed ? 0.68 : 0.62)
+                : PR == 'H' ? (changed ? 0.50 : 0.27) : -1.0;
+    double ui = UI == 'N' ? 0.85 : UI == 'R' ? 0.62 : -1.0;
+    auto cia = [](char m) -> double {
+        switch (m) { case 'H': return 0.56; case 'L': return 0.22; case 'N': return 0.0;
+                     default: return -1; }
+    };
+    double c = cia(C), ii = cia(I), a = cia(A);
+    if (av < 0 || ac < 0 || pr < 0 || ui < 0 || c < 0 || ii < 0 || a < 0) return -1.0;
+    double iss = 1.0 - (1.0 - c) * (1.0 - ii) * (1.0 - a);
+    double impact = changed ? 7.52 * (iss - 0.029) - 3.25 * std::pow(iss - 0.02, 15)
+                            : 6.42 * iss;
+    if (impact <= 0.0) return 0.0;
+    double expl = 8.22 * av * ac * pr * ui;
+    double raw = changed ? 1.08 * (impact + expl) : (impact + expl);
+    if (raw > 10.0) raw = 10.0;
+    return std::ceil(raw * 10.0) / 10.0;  // CVSS 3.1 Roundup to one decimal
+}
+
+// CVSS v2 base score (spec arithmetic). Old CVEs carry only a v2 vector, and the
+// default human view applies a hard High/Critical (>= 7.0) floor, so scoring v2
+// too keeps genuinely severe pre-2016 CVEs visible instead of dropping them for
+// want of a v3 vector. Returns -1.0 on an incomplete vector.
+static double cvss2_base_score(const std::string& vector) {
+    char AV = cvss_metric(vector, "AV"), AC = cvss_metric(vector, "AC");
+    char Au = cvss_metric(vector, "Au"), C = cvss_metric(vector, "C");
+    char I = cvss_metric(vector, "I"), A = cvss_metric(vector, "A");
+    double av = AV == 'N' ? 1.0 : AV == 'A' ? 0.646 : AV == 'L' ? 0.395 : -1;
+    double ac = AC == 'L' ? 0.71 : AC == 'M' ? 0.61 : AC == 'H' ? 0.35 : -1;
+    double au = Au == 'N' ? 0.704 : Au == 'S' ? 0.56 : Au == 'M' ? 0.45 : -1;
+    auto imp = [](char m) -> double {
+        switch (m) { case 'C': return 0.660; case 'P': return 0.275; case 'N': return 0.0;
+                     default: return -1; }
+    };
+    double c = imp(C), i = imp(I), a = imp(A);
+    if (av < 0 || ac < 0 || au < 0 || c < 0 || i < 0 || a < 0) return -1.0;
+    double impact = 10.41 * (1.0 - (1.0 - c) * (1.0 - i) * (1.0 - a));
+    double expl = 20.0 * av * ac * au;
+    double f = impact == 0.0 ? 0.0 : 1.176;
+    double bs = ((0.6 * impact) + (0.4 * expl) - 1.5) * f;
+    if (bs < 0.0) bs = 0.0;
+    return std::round(bs * 10.0) / 10.0;  // v2 rounds to one decimal
+}
+
+// CVSS base score from a vector string, v2 or v3.x. We mirror only the vector
+// (not the number), so recompute it deterministically. -1.0 if unparseable.
+double cvss_base_score(const std::string& vector) {
+    if (vector.rfind("CVSS:3.", 0) == 0) return cvss3_base_score(vector);
+    if (cvss_metric(vector, "Au")) return cvss2_base_score(vector);  // v2 marker
+    return -1.0;
+}
+
+// The default human view keeps only foothold-worthy component CVEs (see cve.hpp).
+// KEV is unconditional (exploited in the wild). Otherwise a hard High/Critical
+// floor applies: Critical (>= 9.0) always shows; below that a CVE must be at least
+// High (>= 7.0), have EPSS traction, be low-complexity, and either carry a real
+// confidentiality/integrity impact or be a *remote* DoS that is actually trending
+// (a higher EPSS bar). Local DoS is dropped entirely. The floor is computed for v2
+// and v3 alike so old CVEs are judged, not hidden by default for lack of a v3
+// vector.
+bool cve_is_high_signal(const CveMatch& m) {
+    if (m.kev) return true;                                       // exploited in the wild
+    double score = cvss_base_score(m.severity);
+    if (score >= kHighSignalCvss) return true;                   // Critical, any shape
+    if (score < kHighFloorCvss) return false;                    // hard floor: High/Critical only
+    if (m.epss < kHighSignalEpss) return false;                  // High needs EPSS traction
+    if (cvss_metric(m.severity, "AC") != 'L') return false;      // drop high-complexity crypto
+    char c = cvss_metric(m.severity, "C"), i = cvss_metric(m.severity, "I");
+    bool has_ci = (c && c != 'N') || (i && i != 'N');            // v2 P/C or v3 L/H
+    if (has_ci) return true;                                     // real confidentiality/integrity impact
+    // Availability-only == DoS. Keep only a REMOTE (AV:N) DoS that is trending;
+    // local/adjacent/physical DoS is not worth a default row.
+    if (cvss_metric(m.severity, "AV") != 'N') return false;
+    return m.epss >= kDosEpss;
+}
 
 std::unordered_set<std::string> load_kev(const std::string& path) {
     std::unordered_set<std::string> out;

--- a/src/cve.hpp
+++ b/src/cve.hpp
@@ -92,6 +92,35 @@ std::vector<CveMatch> cve_join(const Index& db, const std::vector<Component>& co
 // both bases. Deterministic (sorted) output.
 std::vector<CveMatch> reconcile_cves(std::vector<CveMatch> matches);
 
+// CVSS v3.0/v3.1 base score computed from a vector string
+// ("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"). Returns the 0.0-10.0 base
+// score, or -1.0 if `vector` is not a parseable CVSS v3.x base vector (empty,
+// CVSS v2, or missing a required base metric). We store only the vector in the
+// mirror, so this recomputes the number deterministically per the CVSS 3.1 spec.
+double cvss_base_score(const std::string& vector);
+
+// The default human CVE view is gated to foothold-worthy findings for a manual
+// pentester; the JSON view stays complete. A component CVE is "high-signal" if:
+//   - it is on the CISA KEV catalog (exploited in the wild) -- unconditional; OR
+//   - its CVSS base score is >= 9.0 (Critical) -- any shape; OR
+//   - it clears a hard High/Critical floor (base score >= 7.0) AND has EPSS
+//     traction (>= 0.10) AND is low-complexity (AC:L) AND EITHER
+//       * carries a real confidentiality/integrity impact, OR
+//       * is a *remote* DoS (AV:N, availability-only) that is trending (EPSS
+//         >= kDosEpss -- a DoS is lower-yield, so it needs a stronger signal).
+// Local/adjacent/physical DoS is always dropped. The hard floor removes Medium
+// noise that trends on EPSS; the extra impact/complexity test removes the famous
+// but low-yield crypto/DoS CVEs old libraries accumulate (SWEET32, DROWN, padding
+// oracles). A pure DoS cannot reach CVSS 9.0, so the Critical arm needs no test.
+// Scores are computed for CVSS v2 and v3 alike so the floor judges old CVEs
+// instead of hiding them. --component-cves-all bypasses the whole gate; kernel
+// CVEs gate separately.
+constexpr double kHighSignalCvss = 9.0;   // Critical: always shown
+constexpr double kHighFloorCvss = 7.0;    // hard floor: High/Critical only below Critical
+constexpr double kHighSignalEpss = 0.10;  // EPSS traction for a High with real impact
+constexpr double kDosEpss = 0.70;         // stronger EPSS bar for a remote DoS to show
+bool cve_is_high_signal(const CveMatch& m);
+
 // ---- exploit annotations (value-add only; never gate a finding) ----
 // CISA KEV cve ids from kev.json ({"cves":[...]}); empty if the file is absent.
 std::unordered_set<std::string> load_kev(const std::string& path);

--- a/src/human.cpp
+++ b/src/human.cpp
@@ -155,22 +155,63 @@ std::string emit_report_human(const Report& rep, const Passes& passes, const std
     }
 
     // ---- CVE matches ----
+    // The default view is gated to high-signal component CVEs (KEV / CVSS>=9.0 /
+    // EPSS>=0.10) and sorted worst-first, so a manual pentester triages by impact
+    // instead of reading a flat dump of every range match. --component-cves-all
+    // shows the full list; JSON (-j) is always complete regardless of the gate.
     if (passes.cve) {
         if (passes.secrets || passes.sbom) o += "\n";
+
+        // Score + gate every match up front.
+        struct Row { const CveMatch* m; double score; bool high; };
+        std::vector<Row> rows;
+        rows.reserve(rep.cves.size());
+        size_t high_n = 0;
+        for (const auto& m : rep.cves) {
+            bool h = cve_is_high_signal(m);
+            if (h) ++high_n;
+            rows.push_back({&m, cvss_base_score(m.severity), h});
+        }
+        size_t hidden = rep.component_cves_all ? 0 : rep.cves.size() - high_n;
+
         o += a.bold();
         o += std::to_string(rep.cves.size());
         o += rep.cves.size() == 1 ? " CVE" : " CVEs";
         o += a.reset();
+        if (hidden) {
+            o += a.dim();
+            o += "  (" + std::to_string(high_n) + " high-signal shown, " +
+                 std::to_string(hidden) + " hidden)";
+            o += a.reset();
+        }
         o += "\n";
-        if (!rep.cves.empty()) {
+
+        // Rows to render: high-signal only (default) or all (--component-cves-all).
+        std::vector<Row> show;
+        for (const auto& r : rows)
+            if (rep.component_cves_all || r.high) show.push_back(r);
+
+        // The gated view sorts worst-first (KEV, then CVSS, then EPSS); the full
+        // view keeps the join's component-grouped order.
+        if (!rep.component_cves_all) {
+            std::stable_sort(show.begin(), show.end(), [](const Row& x, const Row& y) {
+                if (x.m->kev != y.m->kev) return x.m->kev;
+                if (x.score != y.score) return x.score > y.score;
+                if (x.m->epss != y.m->epss) return x.m->epss > y.m->epss;
+                return x.m->cve_id < y.m->cve_id;
+            });
+        }
+
+        if (!show.empty()) {
             size_t wcve = 3, wcomp = 9;
-            for (const auto& m : rep.cves) {
-                wcve = std::max(wcve, m.cve_id.size());
-                wcomp = std::max(wcomp, m.component.size());
+            for (const auto& r : show) {
+                wcve = std::max(wcve, r.m->cve_id.size());
+                wcomp = std::max(wcomp, r.m->component.size());
             }
             wcomp = std::min<size_t>(wcomp, 32);
             o += "\n";
-            for (const auto& m : rep.cves) {
+            for (const auto& r : show) {
+                const auto& m = *r.m;
                 o += "  ";
                 o += a.yellow();
                 pad(o, m.cve_id, wcve);
@@ -178,6 +219,14 @@ std::string emit_report_human(const Report& rep, const Passes& passes, const std
                 o += "  ";
                 o += a.bold();
                 pad(o, clip(m.component, wcomp), wcomp);
+                o += a.reset();
+                o += "  ";
+                // CVSS base score, colored by band (critical red, high yellow).
+                char sb[8];
+                if (r.score >= 0) std::snprintf(sb, sizeof(sb), "%4.1f", r.score);
+                else std::snprintf(sb, sizeof(sb), " n/a");
+                o += r.score >= 9.0 ? a.red() : r.score >= 7.0 ? a.yellow() : a.dim();
+                o += sb;
                 o += a.reset();
                 o += "  ";
                 o += a.dim();
@@ -195,6 +244,15 @@ std::string emit_report_human(const Report& rep, const Passes& passes, const std
                 }
                 o += "\n";
             }
+        }
+
+        // When the default view hid CVEs, say how to see the rest.
+        if (hidden) {
+            o += a.dim();
+            o += "\n  Gated to high-signal (KEV, or High/Critical CVSS>=7.0 with EPSS "
+                 "traction, real impact or trending remote DoS).\n"
+                 "  Run --component-cves-all for every component CVE in range.\n";
+            o += a.reset();
         }
     }
 

--- a/src/json.cpp
+++ b/src/json.cpp
@@ -83,6 +83,14 @@ void emit_cve(std::string& o, const CveMatch& m) {
     kv_str(o, "component", m.component, first);
     if (!m.component_purl.empty()) kv_str(o, "purl", m.component_purl, first);
     if (!m.severity.empty()) kv_str(o, "severity", m.severity, first);
+    if (double s = cvss_base_score(m.severity); s >= 0) {
+        char b[8];
+        std::snprintf(b, sizeof(b), "%.1f", s);
+        if (!first) o += ",";
+        first = false;
+        o += "\"cvss_score\":";
+        o += b;
+    }
     kv_str(o, "basis", m.basis, first);
     if (!m.summary.empty()) kv_str(o, "summary", m.summary, first);
     if (m.kev) kv_bool(o, "kev", true, first);
@@ -190,6 +198,29 @@ std::string emit_report_json(const Report& rep, const Passes& passes) {
             emit_cve(o, rep.cves[i]);
         }
         o += "]";
+
+        // The "cves" array above is always complete. This records how many of them
+        // the default human view surfaces (gated to KEV / CVSS>=9.0 / EPSS>=0.10),
+        // so a tool caller knows the human triage set without recomputing the gate.
+        if (!rep.cves.empty()) {
+            size_t high = 0;
+            for (const auto& m : rep.cves)
+                if (cve_is_high_signal(m)) ++high;
+            o += ",\"component_cve_scan\":{";
+            bool sf = true;
+            kv_num(o, "total", rep.cves.size(), sf);
+            kv_num(o, "high_signal", high, sf);
+            kv_num(o, "hidden", rep.cves.size() - high, sf);
+            kv_str(o, "gate",
+                   "kev OR cvss>=9.0 OR (cvss>=7.0 AND epss>=0.10 AND AC:L AND "
+                   "(real-C/I-impact OR remote-DoS with epss>=0.70))", sf);
+            kv_str(o, "note",
+                   "the \"cves\" array is complete; \"high_signal\" is the count shown in "
+                   "the default human view; run --component-cves-all to list all in human output",
+                   sf);
+            o += "}";
+        }
+
         o += ",\"kernel_cves\":[";
         for (size_t i = 0; i < rep.kernel_cves.size(); ++i) {
             const auto& k = rep.kernel_cves[i];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -57,6 +57,8 @@ void print_help(std::FILE* out, const char* prog, bool color) {
                  "  -A, --all           Run every pass (the default when none is selected)\n"
                  "      --kernel-cves-all  List every CVE for the detected kernel version, not\n"
                  "                         just the curated set (needs the kernel feed; implies --cve)\n"
+                 "      --component-cves-all  Human view: list every component CVE, not just the\n"
+                 "                         high-signal set (KEV / CVSS>=9.0 / EPSS>=0.10; implies --cve)\n"
                  "      --rules <FILE>  Add user-defined rules from a JSON file\n"
                  "      --fetch-db      Download a prebuilt CVE mirror, then exit\n"
                  "      --update-db     Rebuild the local CVE mirror from source, then exit\n"
@@ -91,6 +93,7 @@ int main(int argc, char** argv) {
     bool fetch_db = false;
     bool dump_kconfig = false;
     bool kernel_cves_all = false;
+    bool component_cves_all = false;
     bool license_paths = false;
     bool with_kernel_feed = false;
     Passes passes;
@@ -137,6 +140,8 @@ int main(int argc, char** argv) {
             dump_kconfig = true;
         } else if (!end_of_opts && std::strcmp(a, "--kernel-cves-all") == 0) {
             kernel_cves_all = true;
+        } else if (!end_of_opts && std::strcmp(a, "--component-cves-all") == 0) {
+            component_cves_all = true;
         } else if (!end_of_opts && std::strcmp(a, "--license-paths") == 0) {
             license_paths = true;
         } else if (!end_of_opts && std::strcmp(a, "--with-kernel-feed") == 0) {
@@ -182,8 +187,10 @@ int main(int argc, char** argv) {
         return 1;
     }
 
-    // --kernel-cves-all is a CVE-pass feature; make sure that pass runs.
+    // --kernel-cves-all / --component-cves-all are CVE-pass features; make sure
+    // that pass runs.
     if (kernel_cves_all) passes.cve = true;
+    if (component_cves_all) passes.cve = true;
     // --license-paths expands the license section; make sure that pass runs.
     if (license_paths) passes.licenses = true;
 
@@ -288,6 +295,10 @@ int main(int argc, char** argv) {
                     if (have.insert(fr.cve).second) rep.kernel_cves.push_back(std::move(fr));
             }
         }
+
+        // Human view gates component CVEs to high-signal (KEV / CVSS>=9.0 /
+        // EPSS>=0.10) unless the user opts into the full list; JSON is unaffected.
+        rep.component_cves_all = component_cves_all;
 
         // Value-add annotation only (never affects applicability): tag findings
         // that are on CISA KEV or carry an EPSS score.

--- a/src/report.hpp
+++ b/src/report.hpp
@@ -57,6 +57,7 @@ struct Report {
     std::vector<CveMatch> cves;         // SBOM-vs-OSV join results
     std::vector<KernelCveResult> kernel_cves;  // curated checklist (+ feed if --kernel-cves-all)
     bool kernel_cves_full = false;      // --kernel-cves-all: the kernel.org feed was merged in
+    bool component_cves_all = false;    // --component-cves-all: show every component CVE in human view
     std::vector<Hit> licenses;          // license findings (SPDX tags + license files)
 
     // Files that could not be read (path -> reason), surfaced for honesty.

--- a/tests/test_cve.py
+++ b/tests/test_cve.py
@@ -20,12 +20,24 @@ ROOT = os.path.dirname(HERE)
 INDEX = {
     "schema": 1, "source": "test-fixture", "generated": "2026-09-05T00:00:00Z",
     "vulns": [
+        # Availability-only DoS (7.5). Gets a high EPSS below, but the human gate
+        # must still hide it: a crash is not a foothold.
         {"id": "CVE-2021-28831", "eco": "Debian", "pkg": "busybox",
          "ev": [["i", "0"], ["f", "1:1.30.1-6"]],
          "sev": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
          "sum": "busybox decompress_gunzip out-of-bounds read"},
+        # Real integrity impact at low complexity (8.8), sub-Critical. Qualifies
+        # only via the EPSS arm and must be SHOWN (a foothold candidate).
+        {"id": "CVE-2099-0002", "eco": "Debian", "pkg": "busybox",
+         "ev": [["i", "0"], ["f", "1:1.30.1-6"]],
+         "sev": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+         "sum": "busybox synthetic memory-corruption fixture"},
     ],
 }
+
+# EPSS scores (annotation): both over the 0.10 bar so both take the EPSS arm; the
+# DoS one is still filtered by impact, the integrity one is kept.
+EPSS = "CVE-2021-28831,0.50\nCVE-2099-0002,0.15\n"
 
 NVD_INDEX = {
     "schema": 1, "source": "test-nvd",
@@ -46,6 +58,12 @@ def run(binary, rootfs, dbdir):
     out = subprocess.check_output([binary, "-j", "--cve", rootfs], env=env,
                                   stderr=subprocess.DEVNULL)
     return json.loads(out)
+
+
+def run_human(binary, rootfs, dbdir, extra=None):
+    env = dict(os.environ, MITHRIL_DB=dbdir, NO_COLOR="1")
+    cmd = [binary, "--cve", rootfs] + (extra or [])
+    return subprocess.check_output(cmd, env=env, stderr=subprocess.DEVNULL).decode()
 
 
 def main():
@@ -71,6 +89,8 @@ def main():
         os.remove(jtmp)
         with open(os.path.join(dbdir, "nvd-index.json"), "w") as f:
             json.dump(NVD_INDEX, f)
+        with open(os.path.join(dbdir, "epss.txt"), "w") as f:
+            f.write(EPSS)
 
         fails = 0
 
@@ -112,9 +132,43 @@ def main():
             print(f"FAIL: NVD/CPE join did not flag openssl 1.1.1m: {rep3.get('cves')}")
             fails += 1
 
+        # Human-view gating. The vuln rootfs has two sub-Critical CVEs, both High
+        # (>= 7.0) with EPSS >= 0.10: a remote availability-only DoS (7.5, EPSS
+        # 0.50) and a real integrity bug (8.8, EPSS 0.15). The DoS is below the
+        # 0.70 remote-DoS bar so it is hidden; the integrity bug is shown. Default
+        # view shows 1 of 2; JSON stays complete + records the outcome.
+        scan = rep.get("component_cve_scan")
+        if not scan or (scan.get("total"), scan.get("high_signal"), scan.get("hidden")) != (2, 1, 1):
+            print(f"FAIL: component_cve_scan gate metadata wrong (want 2/1/1): {scan}")
+            fails += 1
+        if hit and hit.get("cvss_score") != 7.5:
+            print(f"FAIL: cvss_score not recomputed from vector (want 7.5): {hit}")
+            fails += 1
+        h = run_human(binary, os.path.join(d, "vuln"), dbdir)
+        # DoS hidden, integrity bug shown, despite BOTH having high EPSS.
+        if "1 high-signal shown, 1 hidden" not in h:
+            print(f"FAIL: default human view count line wrong:\n{h}")
+            fails += 1
+        if "CVE-2021-28831" in h:
+            print(f"FAIL: availability-only DoS should be hidden despite EPSS 0.50:\n{h}")
+            fails += 1
+        if "CVE-2099-0002" not in h:
+            print(f"FAIL: real-impact CVE should survive the EPSS arm:\n{h}")
+            fails += 1
+        if "--component-cves-all" not in h:
+            print(f"FAIL: gated human view should point to --component-cves-all:\n{h}")
+            fails += 1
+        # --component-cves-all lists every CVE, with no gate banner or footer.
+        hall = run_human(binary, os.path.join(d, "vuln"), dbdir, ["--component-cves-all"])
+        if "CVE-2021-28831" not in hall or "CVE-2099-0002" not in hall or "hidden" in hall:
+            print(f"FAIL: --component-cves-all should list every CVE:\n{hall}")
+            fails += 1
+
         if fails == 0:
             print("PASS: vulnerable busybox flagged CVE-2021-28831 (severity+basis), "
-                  "patched clean, NVD/CPE join flagged openssl 1.1.1m")
+                  "patched clean, NVD/CPE join flagged openssl 1.1.1m, "
+                  "human view gates to foothold-worthy (hard High/Critical floor; remote DoS "
+                  "kept only when trending; --component-cves-all opts out)")
             return 0
         return 1
 

--- a/tests/unit/unit_tests.cpp
+++ b/tests/unit/unit_tests.cpp
@@ -1031,6 +1031,71 @@ static void test_cve() {
     std::remove(idx);
 }
 
+// ---------------------------------------------------- CVSS score + human gate
+static void test_cvss_gate() {
+    using ft::cvss_base_score;
+    // --- CVSS v3.x base scores (spec vectors) ---
+    CHECK(cvss_base_score("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H") == 9.8);  // Critical
+    CHECK(cvss_base_score("CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:H/A:N") == 5.9);  // Terrapin
+    CHECK(cvss_base_score("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H") == 7.5);  // remote DoS
+    CHECK(cvss_base_score("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H") == 10.0); // scope-changed
+    CHECK(cvss_base_score("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N") == 0.0);  // no impact
+    CHECK(cvss_base_score("CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H") == 9.8);  // v3.0 prefix
+    // --- CVSS v2 base scores (now computed too, for the hard floor) ---
+    CHECK(cvss_base_score("AV:N/AC:L/Au:N/C:P/I:P/A:P") == 7.5);   // classic 7.5 v2
+    CHECK(cvss_base_score("AV:N/AC:L/Au:N/C:C/I:C/A:C") == 10.0);  // full-impact v2 -> 10.0
+    CHECK(cvss_base_score("AV:L/AC:H/Au:N/C:P/I:N/A:N") == 1.2);   // local, low v2
+    // --- unparseable -> -1.0 ---
+    CHECK(cvss_base_score("") == -1.0);
+    CHECK(cvss_base_score("CVSS:3.1/AV:N/AC:L") == -1.0);          // v3 missing metrics
+    CHECK(cvss_base_score("CVSS:3.1/AV:X/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H") == -1.0);  // bad value
+    CHECK(cvss_base_score("AV:N/AC:L/Au:N/C:P/I:P") == -1.0);      // v2 missing A
+
+    auto mk = [](const char* cvss, bool kev, double epss) {
+        ft::CveMatch m;
+        m.cve_id = "CVE-X";
+        m.severity = cvss;
+        m.kev = kev;
+        m.epss = epss;
+        return m;
+    };
+    // KEV is unconditional -- even a Medium, even AC:H, even no EPSS.
+    CHECK(ft::cve_is_high_signal(mk("CVSS:3.1/AV:L/AC:H/PR:H/UI:R/S:U/C:L/I:N/A:N", true, 0.0)));
+    // Critical (>= 9.0) always shows, any shape / EPSS.
+    CHECK(ft::cve_is_high_signal(mk("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", false, 0.0)));
+
+    // --- the hard High/Critical floor: Mediums are dropped even with high EPSS ---
+    // CVE-2017-3735 shape (5.3, I:L only), EPSS 0.21 -> hidden.
+    CHECK(!ft::cve_is_high_signal(mk("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N", false, 0.21)));
+    // CVE-2017-3736 shape (6.5, DoS), EPSS 0.10 -> hidden (below 7.0).
+    CHECK(!ft::cve_is_high_signal(mk("CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H", false, 0.10)));
+
+    // --- High band (7.0-8.9): needs EPSS traction + low complexity + real impact ---
+    // 8.8 real integrity impact, EPSS over the bar -> shown; under the bar -> hidden.
+    CHECK(ft::cve_is_high_signal(mk("CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H", false, 0.15)));
+    CHECK(!ft::cve_is_high_signal(mk("CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H", false, 0.05)));
+    // High-complexity crypto (DROWN shape, C:H/AC:H) -> hidden regardless of EPSS.
+    CHECK(!ft::cve_is_high_signal(mk("CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N", false, 0.82)));
+    // Heartbleed shape (C:H, AC:L, network) at High with EPSS -> shown.
+    CHECK(ft::cve_is_high_signal(mk("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N", false, 0.20)));
+
+    // --- DoS handling: remote kept only if trending; local dropped ---
+    // Remote DoS (AV:N, avail-only, 7.5): EPSS >= 0.70 shown, below hidden.
+    CHECK(ft::cve_is_high_signal(mk("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H", false, 0.73)));
+    CHECK(!ft::cve_is_high_signal(mk("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H", false, 0.50)));
+    // Local DoS: AV:L, avail-only, scored 7.1 via scope change, EPSS 0.95 -> hidden
+    // (local availability is not worth a default row).
+    CHECK(!ft::cve_is_high_signal(mk("CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:C/C:N/I:N/A:H", false, 0.95)));
+
+    // --- v2 CVEs are judged by the same floor (not hidden for lack of a v3 vector) ---
+    // v2 10.0 full-impact, EPSS over the bar -> shown.
+    CHECK(ft::cve_is_high_signal(mk("AV:N/AC:L/Au:N/C:C/I:C/A:C", false, 0.20)));
+    // v2 7.5 (C:P/I:P/A:P real impact), EPSS over the bar -> shown.
+    CHECK(ft::cve_is_high_signal(mk("AV:N/AC:L/Au:N/C:P/I:P/A:P", false, 0.20)));
+    // v2 Medium (local, 1.2) -> hidden by the floor even with high EPSS.
+    CHECK(!ft::cve_is_high_signal(mk("AV:L/AC:H/Au:N/C:P/I:N/A:N", false, 0.90)));
+}
+
 // ---------------------------------------------------------------- nvd/cpe join
 static void test_nvd() {
     // affected-range evaluation
@@ -1382,6 +1447,7 @@ int main() {
     test_userrules();
     test_version();
     test_cve();
+    test_cvss_gate();
     test_nvd();
     test_rpm();
     test_langmanifest();


### PR DESCRIPTION
## Summary

The default `--cve` human output listed every version-range match flat and
unranked. On a real firmware image that is dozens to hundreds of CVEs of every
severity with no triage signal. This gates the default human view to the
findings a reviewer acts on, and keeps the JSON view complete for tooling.

## The gate

A component CVE shows in the default human view if:

- it is on **CISA KEV** (exploited in the wild) — unconditional; or
- it is **Critical** (CVSS base score >= 9.0) — unconditional; or
- it clears a **hard High/Critical floor** (CVSS >= 7.0) **and** has EPSS
  traction (>= 0.10) **and** is low attack complexity (AC:L) **and** either
  carries a real confidentiality/integrity impact **or** is a *remote* DoS
  (AV:N, availability-only) that is trending (EPSS >= 0.70).

Dropped by default: Mediums, local/adjacent/physical DoS, and the
high-complexity MITM/side-channel crypto class (which trend high on EPSS but
need exotic conditions). Rows are sorted worst-first and show the CVSS score.

## Notable details

- **CVSS base score is recomputed from the stored vector** for CVSS v3.0/v3.1
  and v2 alike, so the hard floor judges old (v2-only) CVEs instead of hiding
  them for lack of a v3 vector.
- **`--component-cves-all`** opts into the full component-CVE list in the human
  view (parallels the existing `--kernel-cves-all`).
- **JSON is unaffected**: the `cves[]` array stays the complete join, each entry
  gains a `cvss_score`, and a `component_cve_scan` object records
  `total` / `high_signal` / `hidden` / `gate` so a tool caller sees the triage
  outcome.

## Known limitation

The CVSS vector encodes impact and complexity, not weakness *class*, so a crypto
weakness scored `C:H`/`AC:L` can still show and a memory-corruption bug scored
availability-only can be dropped. The precise fix is CWE-class filtering
(documented in `docs/cve-join.md`), deferred.

## Tests

- Unit suite expanded to 359 checks: CVSS v2/v3 base-score arithmetic, the hard
  floor, remote-vs-local DoS handling, and the EPSS thresholds.
- Integration coverage in `tests/test_cve.py`: a High DoS below the remote-DoS
  bar is hidden while a real-impact High is shown; `--component-cves-all` lists
  everything.
- Full suite green on gcc and clang, clean under ASan/UBSan, fuzz smoke clean.
